### PR TITLE
Remove a record if last entry is not healthy anymore

### DIFF
--- a/dns/route53/client.go
+++ b/dns/route53/client.go
@@ -9,9 +9,17 @@ import (
 	route53Client "github.com/aws/aws-sdk-go/service/route53"
 )
 
+// r53 is the minimal interface to the route 53 client used for client mocking
+// in unit testing
+type r53 interface {
+	ChangeResourceRecordSets(input *route53Client.ChangeResourceRecordSetsInput) (*route53Client.ChangeResourceRecordSetsOutput, error)
+	ListResourceRecordSets(input *route53Client.ListResourceRecordSetsInput) (*route53Client.ListResourceRecordSetsOutput, error)
+	ListHostedZonesByName(input *route53Client.ListHostedZonesByNameInput) (*route53Client.ListHostedZonesByNameOutput, error)
+}
+
 // Client wraps the AWS Route53 service
 type Client struct {
-	Service *route53Client.Route53
+	Service r53
 }
 
 // NewClient constructs a new Service, wrapping a aws route53 client under the hood.

--- a/dns/route53/dns.go
+++ b/dns/route53/dns.go
@@ -1,9 +1,7 @@
 package route53
 
 import (
-	"fmt"
 	"net"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	route53Client "github.com/aws/aws-sdk-go/service/route53"
@@ -56,18 +54,7 @@ func (s *SRVManager) edit(add bool, srv *net.SRV) error {
 	} else {
 		resourceRecordSet.ResourceRecords = newResourceRecords
 
-		recordSetInput := &route53Client.ChangeResourceRecordSetsInput{
-			HostedZoneId: aws.String(s.hostedZoneID),
-			ChangeBatch: &route53Client.ChangeBatch{
-				Comment: aws.String(fmt.Sprintf("Updated automatically on %s", time.Now().Format(time.RFC3339))),
-				Changes: []*route53Client.Change{{
-					Action:            aws.String(route53Client.ChangeActionUpsert),
-					ResourceRecordSet: resourceRecordSet,
-				}},
-			},
-		}
-
-		_, err := s.client.Service.ChangeResourceRecordSets(recordSetInput)
+		_, err := s.client.ChangeRecord(s.hostedZoneID, route53Client.ChangeActionUpsert, resourceRecordSet)
 		if err != nil {
 			return err
 		}

--- a/dns/route53/dns_integration_test.go
+++ b/dns/route53/dns_integration_test.go
@@ -1,0 +1,63 @@
+// +build integration
+
+package route53
+
+import (
+	"testing"
+
+	"fmt"
+	"net"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIntegrationAddAndRemoveATarget requires valid AWS credentials being available
+// DOCS: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+func TestIntegrationAddAndRemoveATarget(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+
+	zoneName := os.Getenv("TEST_ZONE_NAME")
+	if zoneName == "" {
+		t.Fatal("Missing environment variable: TEST_ZONE_NAME. Mark as failed")
+	}
+
+	recordName := fmt.Sprintf("%s.%s", "_srv._tcp.test", zoneName)
+	ttl := uint16(60)
+	client := NewClient()
+	dnsZone, err := client.GetZoneByName(zoneName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostedZoneID := aws.StringValue(dnsZone.Id)
+
+	srvManager := NewSRVManager(
+		client,
+		hostedZoneID,
+		recordName,
+		ttl,
+	)
+
+	record := &net.SRV{
+		Priority: 10,
+		Weight:   20,
+		Port:     4242,
+		Target:   "sub.domain.test.",
+	}
+
+	err = srvManager.Add(record)
+	if assert.NoError(t, err) {
+		resourceRecordSet, err := srvManager.client.GetResourceRecordSetByName(hostedZoneID, recordName, "SRV")
+		assert.NoError(t, err)
+		assert.NotNil(t, resourceRecordSet, "Record should exist")
+	}
+
+	err = srvManager.Remove(record)
+	if assert.NoError(t, err) {
+		resourceRecordSet, err := srvManager.client.GetResourceRecordSetByName(hostedZoneID, recordName, "SRV")
+		assert.NoError(t, err)
+		assert.Nil(t, resourceRecordSet, "Record should not exist")
+	}
+}

--- a/dns/route53/dns_test.go
+++ b/dns/route53/dns_test.go
@@ -1,0 +1,115 @@
+package route53
+
+import (
+	"testing"
+	"time"
+
+	"fmt"
+	"net"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/route53"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockR53 struct {
+	recordSet *route53.ResourceRecordSet
+	zoneID    string
+}
+
+func (r53 *mockR53) ChangeResourceRecordSets(input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
+	// NOTE: if the ChangeBatch would contain more than just one Change, they would be ignored
+	change := input.ChangeBatch.Changes[0]
+
+	switch *change.Action {
+	case route53.ChangeActionCreate, route53.ChangeActionUpsert:
+		r53.recordSet = change.ResourceRecordSet
+
+	case route53.ChangeActionDelete:
+		r53.recordSet = nil
+
+	default:
+		panic(fmt.Sprintf("Invalid action: %s", *change.Action))
+	}
+
+	return &route53.ChangeResourceRecordSetsOutput{
+		ChangeInfo: &route53.ChangeInfo{
+			Id:          aws.String("MOCKED-AWS-API-ID"),
+			Status:      aws.String("INSYNC"),
+			SubmittedAt: aws.Time(time.Now()),
+		},
+	}, nil
+}
+
+func (r53 *mockR53) ListResourceRecordSets(input *route53.ListResourceRecordSetsInput) (*route53.ListResourceRecordSetsOutput, error) {
+	recordName := *input.StartRecordName
+
+	resourceRecordSets := []*route53.ResourceRecordSet{}
+	if r53.recordSet != nil && *r53.recordSet.Name == recordName {
+		resourceRecordSets = append(resourceRecordSets, r53.recordSet)
+	}
+
+	return &route53.ListResourceRecordSetsOutput{
+		ResourceRecordSets: resourceRecordSets,
+		IsTruncated:        aws.Bool(false),
+		MaxItems:           input.MaxItems,
+	}, nil
+}
+
+// NOTE: always returns a list of one item matching the queried DNSName
+func (r53 *mockR53) ListHostedZonesByName(input *route53.ListHostedZonesByNameInput) (*route53.ListHostedZonesByNameOutput, error) {
+	return &route53.ListHostedZonesByNameOutput{
+		HostedZones: []*route53.HostedZone{
+			&route53.HostedZone{
+				Id:              aws.String(r53.zoneID),
+				CallerReference: aws.String("MOCKED-CAL-REF"),
+				Name:            input.DNSName,
+			},
+		},
+		IsTruncated: aws.Bool(false),
+		MaxItems:    input.MaxItems,
+	}, nil
+}
+
+func TestAddAndRemoveATarget(t *testing.T) {
+	log.SetLevel(log.DebugLevel)
+
+	mockedZoneID := "20N31D"
+	recordName := fmt.Sprintf("%s.%s", "_srv._tcp.test", "example.com")
+	ttl := uint16(60)
+	client := &Client{
+		Service: &mockR53{
+			recordSet: nil,
+			zoneID:    mockedZoneID,
+		},
+	}
+
+	srvManager := NewSRVManager(
+		client,
+		mockedZoneID,
+		recordName,
+		ttl,
+	)
+
+	record := &net.SRV{
+		Priority: 10,
+		Weight:   20,
+		Port:     4242,
+		Target:   "sub.domain.test.",
+	}
+
+	err := srvManager.Add(record)
+	if assert.NoError(t, err) {
+		resourceRecordSet, err := srvManager.client.GetResourceRecordSetByName(mockedZoneID, recordName, "SRV")
+		assert.NoError(t, err)
+		assert.NotNil(t, resourceRecordSet, "Record should exist")
+	}
+
+	err = srvManager.Remove(record)
+	if assert.NoError(t, err) {
+		resourceRecordSet, err := srvManager.client.GetResourceRecordSetByName(mockedZoneID, recordName, "SRV")
+		assert.NoError(t, err)
+		assert.Nil(t, resourceRecordSet, "Record should not exist")
+	}
+}


### PR DESCRIPTION
ResourceRecords must always be greater than 0. So, in order for
this to work, we take the ResourceRecordSet as is and not assign
an empty slice (newResourceRecords for this specific case)