### PR TITLE
Use channels

### DIFF
--- a/checker/healthchecks/main.go
+++ b/checker/healthchecks/main.go
@@ -1,0 +1,12 @@
+package healthchecks
+
+import "context"
+
+// IHealthcheck describes the basic healthchecker interface
+type IHealthcheck interface {
+	// Run will run the healthchecker-specific check
+	// in healthchecker-specific intervals.
+	// They will regularily push their health status
+	// to the healthyChan.
+	Run(ctx context.Context, healthyChan chan<- bool)
+}

--- a/checker/healthchecks/mock/main.go
+++ b/checker/healthchecks/mock/main.go
@@ -1,0 +1,26 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/zinfra/srv-announcer/checker/healthchecks"
+)
+
+// Healthcheck exposes a HealthC channel, which is is piped through from Run()
+type Healthcheck struct {
+	HealthC chan bool
+}
+
+// ensure Healthcheck implements IHealthcheck
+var _ healthchecks.IHealthcheck = &Healthcheck{}
+
+func (h *Healthcheck) Run(ctx context.Context, healthyChan chan<- bool) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case health := <-h.HealthC:
+			healthyChan <- health
+		}
+	}
+}

--- a/checker/healthchecks/tcp/main.go
+++ b/checker/healthchecks/tcp/main.go
@@ -1,4 +1,4 @@
-package checker
+package tcp
 
 import (
 	"context"
@@ -7,22 +7,24 @@ import (
 
 	"github.com/lthibault/jitterbug"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/zinfra/srv-announcer/checker/healthchecks"
 )
 
 // ensure TCPHealthcheck implements IHealthcheck
-var _ IHealthcheck = &TCPHealthcheck{}
+var _ healthchecks.IHealthcheck = &Healthcheck{}
 
-// TCPHealthcheck checks whether it's able to connect to a given target
+// Healthcheck checks whether it's able to connect to a given target
 // via TCP
-type TCPHealthcheck struct {
+type Healthcheck struct {
 	target         string
 	connectTimeout time.Duration
 	checkInterval  time.Duration
 }
 
-// NewTCPHealthcheck creates a new TCPHealthcheck
-func NewTCPHealthcheck(target string, connectTimeout time.Duration, checkInterval time.Duration) *TCPHealthcheck {
-	return &TCPHealthcheck{
+// NewHealthcheck creates a new Healthcheck
+func NewHealthcheck(target string, connectTimeout time.Duration, checkInterval time.Duration) *Healthcheck {
+	return &Healthcheck{
 		target:         target,
 		connectTimeout: connectTimeout,
 		checkInterval:  checkInterval,
@@ -31,7 +33,7 @@ func NewTCPHealthcheck(target string, connectTimeout time.Duration, checkInterva
 
 // Run regularily tries to connect to the target via TCP,
 // sends true if it was able to, false otherwise
-func (hc *TCPHealthcheck) Run(ctx context.Context, healthyChan chan<- bool) {
+func (hc *Healthcheck) Run(ctx context.Context, healthyChan chan<- bool) {
 	// jitter around a 10th of the configured interval
 	t := jitterbug.New(hc.checkInterval, &jitterbug.Norm{Stdev: hc.checkInterval / 10})
 

--- a/checker/main.go
+++ b/checker/main.go
@@ -6,19 +6,12 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	dns "github.com/zinfra/srv-announcer/dns"
+
+	"github.com/zinfra/srv-announcer/checker/healthchecks"
 )
 
-// IHealthcheck describes the basic healthchecker interface
-type IHealthcheck interface {
-	// Run will run the healthchecker-specific check
-	// in healthchecker-specific intervals.
-	// They will regularily push their health status
-	// to the healthyChan.
-	Run(ctx context.Context, healthyChan chan<- bool)
-}
-
 // Run runs a healthcheck and updates the SRV record whenever its status changes
-func Run(ctx context.Context, healthcheck IHealthcheck, srvRecord *net.SRV, srvManager dns.ISRVManager) error {
+func Run(ctx context.Context, healthcheck healthchecks.IHealthcheck, srvRecord *net.SRV, srvManager dns.ISRVManager) error {
 	var err error
 	var healthyC chan bool
 

--- a/checker/main.go
+++ b/checker/main.go
@@ -1,52 +1,59 @@
 package checker
 
 import (
-	"net"
-	"time"
+	"context"
 
-	"github.com/lthibault/jitterbug"
 	log "github.com/sirupsen/logrus"
 	config "github.com/zinfra/srv-announcer/config"
 	dns "github.com/zinfra/srv-announcer/dns"
 )
 
-func tcpReachable(target string, checkTimeout time.Duration) bool {
-	timeout := checkTimeout
-	conn, err := net.DialTimeout("tcp", target, timeout)
-
-	if err != nil {
-		log.Infof("%s is unreachable", target)
-		return false
-	}
-	defer conn.Close()
-	log.Infof("%s is reachable", target)
-	return true
+// IHealthcheck describes the basic healthchecker interface
+type IHealthcheck interface {
+	// Run will run the healthchecker-specific check
+	// in healthchecker-specific intervals.
+	// They will regularily push their health status
+	// to the healthyChan.
+	Run(ctx context.Context, healthyChan chan<- bool)
 }
 
 // Run runs the healthchecks and updates the SRV record
-func Run(config *config.Config, srvManager dns.ISRVManager) error {
-	// jitter around a 10th of the configured interval
-	jitter := &jitterbug.Norm{Stdev: (config.CheckInterval / 10)}
-	t := jitterbug.New(
-		config.CheckInterval,
-		jitter,
-	)
+func Run(ctx context.Context, config *config.Config, srvManager dns.ISRVManager) error {
+	var err error
 
-	// initially wait the jitter time
-	time.Sleep(t.Jitter.Jitter(config.CheckInterval / 10))
+	// start a TCP Health checker
+	tcpHc := NewTCPHealthcheck(config.CheckTarget, config.CheckTimeout, config.CheckInterval)
+	tcpHcC := make(chan bool, 1)
+	go tcpHc.Run(ctx, tcpHcC)
 
-	for range t.C {
-		var err error
-		if tcpReachable(config.CheckTarget, config.CheckTimeout) {
-			err = srvManager.Add(&config.SRVRecord)
-		} else {
-			err = srvManager.Remove(&config.SRVRecord)
-		}
-		if err != nil {
-			// only log the error here, don't exit the check loop.
-			// It might be a networking blip - we usually want to
-			// keep doing health checks.
-			log.Errorf("%s", err.Error())
+	for {
+		select {
+		case <-ctx.Done():
+			srvManager.Remove(&config.SRVRecord)
+			return nil
+		case isReachable := <-tcpHcC:
+			log.Infof("got data on healthyC: %t", isReachable)
+			if isReachable {
+				err = srvManager.Add(&config.SRVRecord)
+			} else {
+				err = srvManager.Remove(&config.SRVRecord)
+			}
+			if err != nil {
+				// only log the error here, don't exit the check loop.
+				// It might be a networking blip - we usually want to
+				// keep doing health checks.
+				log.Errorf("%s", err.Error())
+					err = srvManager.Add(srvRecord)
+				} else {
+					err = srvManager.Remove(srvRecord)
+				}
+				if err != nil {
+					// only log the error here, don't exit the check loop.
+					// It might be a networking blip - we usually want to
+					// keep doing health checks.
+					log.Errorf("%s", err.Error())
+				}
+			}
 		}
 	}
 	return nil

--- a/checker/main_test.go
+++ b/checker/main_test.go
@@ -1,0 +1,71 @@
+package checker
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zinfra/srv-announcer/checker/healthchecks/mock"
+	"github.com/zinfra/srv-announcer/dns/dummy"
+)
+
+// TestChecker tests Healthcheck.Run.
+// It passes in a mock.Healthcheck and a dummySrvManager, then
+// uses the mock.Healthcheck.HealthC channel to change health
+// and inspects dummySrvManagers rrset afterwards
+// it also tests the record is removed from the set once the context is cancelled
+func TestChecker(t *testing.T) {
+	// setup tooling
+	mockHealthcheck := &mock.Healthcheck{
+		HealthC: make(chan bool, 1),
+	}
+
+	dummySrv := &net.SRV{
+		Priority: 10,
+		Weight:   20,
+		Port:     4242,
+		Target:   "foobar.example.com.",
+	}
+
+	dummySrvManager := &dummy.SrvManager{}
+
+	// setup context
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	// kick off the checker
+	go Run(ctx, mockHealthcheck, dummySrv, dummySrvManager)
+
+	assert.Len(t, dummySrvManager.SrvRecordSet, 0, "Initially rrset should be empty")
+
+	// let service become healthy
+	mockHealthcheck.HealthC <- true
+
+	assert.Eventually(t, func() bool {
+		return len(dummySrvManager.SrvRecordSet) != 0
+	}, 50*time.Millisecond, time.Millisecond, "rrset should eventually not be empty anymore")
+	assert.Equal(t, *dummySrv, dummySrvManager.SrvRecordSet[0], "rrset should contain dummySrv")
+
+	// let service become unhealthy
+	mockHealthcheck.HealthC <- false
+
+	assert.Eventually(t, func() bool {
+		return len(dummySrvManager.SrvRecordSet) == 0
+	}, 50*time.Millisecond, time.Millisecond, "rrset should eventually become empty again")
+
+	// make service healthy again so we can test teardown
+	mockHealthcheck.HealthC <- true
+
+	assert.Eventually(t, func() bool {
+		return len(dummySrvManager.SrvRecordSet) != 0
+	}, 50*time.Millisecond, time.Millisecond, "rrset should eventually not be empty anymore")
+
+	// cancel context
+	cancelCtx()
+
+	assert.Eventually(t, func() bool {
+		return len(dummySrvManager.SrvRecordSet) == 0
+	}, 50*time.Millisecond, time.Millisecond, "rrset should eventually become empty on teardown")
+
+}

--- a/checker/tcp.go
+++ b/checker/tcp.go
@@ -1,0 +1,54 @@
+package checker
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/lthibault/jitterbug"
+	log "github.com/sirupsen/logrus"
+)
+
+// ensure TCPHealthcheck implements IHealthcheck
+var _ IHealthcheck = &TCPHealthcheck{}
+
+// TCPHealthcheck checks whether it's able to connect to a given target
+// via TCP
+type TCPHealthcheck struct {
+	target         string
+	connectTimeout time.Duration
+	checkInterval  time.Duration
+}
+
+// NewTCPHealthcheck creates a new TCPHealthcheck
+func NewTCPHealthcheck(target string, connectTimeout time.Duration, checkInterval time.Duration) *TCPHealthcheck {
+	return &TCPHealthcheck{
+		target:         target,
+		connectTimeout: connectTimeout,
+		checkInterval:  checkInterval,
+	}
+}
+
+// Run regularily tries to connect to the target via TCP,
+// sends true if it was able to, false otherwise
+func (hc *TCPHealthcheck) Run(ctx context.Context, healthyChan chan<- bool) {
+	// jitter around a 10th of the configured interval
+	t := jitterbug.New(hc.checkInterval, &jitterbug.Norm{Stdev: hc.checkInterval / 10})
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			conn, err := net.DialTimeout("tcp", hc.target, hc.connectTimeout)
+			if err != nil {
+				log.Infof("%s is unreachable", hc.target)
+				healthyChan <- false
+				continue
+			}
+			defer conn.Close()
+			log.Infof("%s is reachable", hc.target)
+			healthyChan <- true
+		}
+	}
+}

--- a/config/main.go
+++ b/config/main.go
@@ -11,7 +11,7 @@ type Config struct {
 	ZoneName      string
 	SRVRecordName string
 	TTL           uint16
-	SRVRecord     net.SRV
+	SRVRecord     *net.SRV
 	CheckTarget   string
 	CheckInterval time.Duration
 	CheckTimeout  time.Duration

--- a/dns/dummy/main.go
+++ b/dns/dummy/main.go
@@ -1,0 +1,51 @@
+package dummy
+
+import (
+	"net"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/zinfra/srv-announcer/dns"
+)
+
+// ensure SrvManager implements ISRVManager
+var _ dns.ISRVManager = &SrvManager{}
+
+// SrvManager implements the ISrvManager interface, but doesn't talk to any real service
+// instead, it just logs and exposes its struct.
+type SrvManager struct {
+	SrvRecordSet []net.SRV
+}
+
+// Add adds the record to the record set if it doesn't already exist
+func (s *SrvManager) Add(srv *net.SRV) error {
+	log.Info("add called")
+	// if that record is in the set already, we're done
+	for _, aSrv := range s.SrvRecordSet {
+		if aSrv.Port == srv.Port && aSrv.Priority == srv.Priority &&
+			aSrv.Target == srv.Target && aSrv.Weight == aSrv.Weight {
+			log.Debugf("Record %+v already exists, doing nothing", aSrv)
+			return nil
+		}
+	}
+	// else append it
+	log.Infof("Adding record %+v to record set", srv)
+	s.SrvRecordSet = append(s.SrvRecordSet, *srv)
+	return nil
+}
+
+// Remove removes the record to the record set if it exists
+func (s *SrvManager) Remove(srv *net.SRV) error {
+	log.Info("remove called")
+	newRecordSet := make([]net.SRV, 0)
+	for _, aSrv := range s.SrvRecordSet {
+		// if that record is in the set already, remove it, else copy it over
+		if aSrv.Port == srv.Port && aSrv.Priority == srv.Priority &&
+			aSrv.Target == srv.Target && aSrv.Weight == aSrv.Weight {
+			log.Debugf("Removing record %+v from list", aSrv)
+		} else {
+			newRecordSet = append(newRecordSet, aSrv)
+		}
+	}
+	s.SrvRecordSet = newRecordSet
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func main() {
 		},
 	}
 
-	app.Action = func(c *cli.Context) error {
+	app.Action = func(ctx *cli.Context) error {
 		// there's no uint16flag, so scan into uint and convert here.
 		config.TTL = uint16(TTL)
 		config.SRVRecord.Port = uint16(srvPort)
@@ -131,7 +131,7 @@ func main() {
 
 		srvRecordManager := route53.NewSRVManager(r53, zoneID, config.SRVRecordName, config.TTL, config.DryRun)
 
-		return checker.Run(&config, srvRecordManager)
+		return checker.Run(ctx.Context, &config, srvRecordManager)
 	}
 
 	err := app.Run(os.Args)

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -20,6 +21,7 @@ func main() {
 	log.SetLevel(log.DebugLevel)
 
 	var config config.Config
+	config.SRVRecord = &net.SRV{}
 	var checkTarget string
 	var TTL, srvPort, srvPriority, srvWeight uint
 
@@ -131,7 +133,9 @@ func main() {
 
 		srvRecordManager := route53.NewSRVManager(r53, zoneID, config.SRVRecordName, config.TTL, config.DryRun)
 
-		return checker.Run(ctx.Context, &config, srvRecordManager)
+		tcpHealthcheck := checker.NewTCPHealthcheck(config.CheckTarget, config.CheckTimeout, config.CheckInterval)
+
+		return checker.Run(ctx.Context, tcpHealthcheck, config.SRVRecord, srvRecordManager)
 	}
 
 	err := app.Run(os.Args)

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	checker "github.com/zinfra/srv-announcer/checker"
+	tcpHealthcheck "github.com/zinfra/srv-announcer/checker/healthchecks/tcp"
 	config "github.com/zinfra/srv-announcer/config"
 	route53 "github.com/zinfra/srv-announcer/dns/route53"
 )
@@ -133,7 +134,7 @@ func main() {
 
 		srvRecordManager := route53.NewSRVManager(r53, zoneID, config.SRVRecordName, config.TTL, config.DryRun)
 
-		tcpHealthcheck := checker.NewTCPHealthcheck(config.CheckTarget, config.CheckTimeout, config.CheckInterval)
+		tcpHealthcheck := tcpHealthcheck.NewHealthcheck(config.CheckTarget, config.CheckTimeout, config.CheckInterval)
 
 		return checker.Run(ctx.Context, tcpHealthcheck, config.SRVRecord, srvRecordManager)
 	}


### PR DESCRIPTION
This refactors the code to use channels, and shifts some responsibilities:

 - Healthchecks report health status to a channel that they're initialized with
 - `checker.Run` knows about context, and will remove the record when the context is cancelled (solves https://github.com/wireapp/srv-announcer/pull/7)
 - `checker.Run` already didn't care about initializing the srv manager - same applies for the healthcheck now. As a bonus, we don't need to know `config` anymore.
 - due to that, we can now properly test `checker.Run`