### PR TITLE
main.go: warn if srv record target doesn't end with a dot

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 		},
 		&cli.StringFlag{
 			Name:        "srv-record-target",
-			Usage:       "Target of the RFC2782 SRV Record. Usualy something resembling your hostname.",
+			Usage:       "Target of the RFC2782 SRV Record. Usually something resembling your hostname.",
 			EnvVars:     []string{"SRV_ANNOUNCER_SRV_RECORD_TARGET"},
 			Destination: &config.SRVRecord.Target,
 			Required:    true,

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 		},
 		&cli.StringFlag{
 			Name:        "srv-record-target",
-			Usage:       "Target of the RFC2782 SRV Record. Usually something resembling your hostname.",
+			Usage:       "Target of the RFC2782 SRV Record. Usually something resembling your hostname, ending with a dot",
 			EnvVars:     []string{"SRV_ANNOUNCER_SRV_RECORD_TARGET"},
 			Destination: &config.SRVRecord.Target,
 			Required:    true,


### PR DESCRIPTION
This warns (but doesn't fail) if the `--srv-record-target` passed
doesn't end with a dot.
    
This also updates the check target calculation, which is derived from
$srv-record-target and $srv-record-port if unspecified to strip the
trailing dot.
    
While the `net.DialTimeout` (and by this, the TCP healthchecker) work
with a trailing dot, it looks a bit odd there.
