### PR TITLE
run golint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.14.6"
+      - run: go get -u golang.org/x/lint/golint && golint -set_exit_status ./...
       - run: go test ./...
       - run: CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' .
       - uses: actions/upload-artifact@v2

--- a/checker/healthchecks/mock/main.go
+++ b/checker/healthchecks/mock/main.go
@@ -14,6 +14,8 @@ type Healthcheck struct {
 // ensure Healthcheck implements IHealthcheck
 var _ healthchecks.IHealthcheck = &Healthcheck{}
 
+// Run waits on either the context being closed, or something received on the
+// public HealthC channel (which is just piped through to healthyChan
 func (h *Healthcheck) Run(ctx context.Context, healthyChan chan<- bool) {
 	for {
 		select {


### PR DESCRIPTION
This adds running `golint` to CI, and adresses its only remaining nit before.