### PR TITLE
main.go: Instantiate Dummy SRV manager when --dry-run is passed

### DIFF
--- a/dns/route53/dns.go
+++ b/dns/route53/dns.go
@@ -17,20 +17,18 @@ type SRVManager struct {
 	hostedZoneID string
 	recordName   string
 	ttl          uint16
-	dryRun       bool
 }
 
 // ensure SRVManager implements dns.ISRVManager
 var _ dns.ISRVManager = &SRVManager{}
 
 // NewSRVManager initializes an SRV Manager by its zone ID and record name
-func NewSRVManager(client *Client, hostedZoneID string, recordName string, ttl uint16, dryRun bool) *SRVManager {
+func NewSRVManager(client *Client, hostedZoneID string, recordName string, ttl uint16) *SRVManager {
 	return &SRVManager{
 		client:       client,
 		hostedZoneID: hostedZoneID,
 		recordName:   recordName,
 		ttl:          ttl,
-		dryRun:       dryRun,
 	}
 }
 
@@ -69,13 +67,9 @@ func (s *SRVManager) edit(add bool, srv *net.SRV) error {
 			},
 		}
 
-		if s.dryRun {
-			log.Debugf("would now change records as following: %+v", recordSetInput)
-		} else {
-			_, err := s.client.Service.ChangeResourceRecordSets(recordSetInput)
-			if err != nil {
-				return err
-			}
+		_, err := s.client.Service.ChangeResourceRecordSets(recordSetInput)
+		if err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Also, remove the "dry run" mode in the Route53 SRV Manager.

There's few benefit in a dry-run that verifies it can read (but not
write) DNS records in Route53, and making the --dry-run flag actually
use the dummy srv manager (which does log) allows smoketesting it
without needing to be able to connect to Route53.