### PR TITLE
unify log levels

### DIFF
--- a/dns/dummy/main.go
+++ b/dns/dummy/main.go
@@ -18,7 +18,7 @@ type SrvManager struct {
 
 // Add adds the record to the record set if it doesn't already exist
 func (s *SrvManager) Add(srv *net.SRV) error {
-	log.Info("add called")
+	log.Debug("Add called")
 	// if that record is in the set already, we're done
 	for _, aSrv := range s.SrvRecordSet {
 		if aSrv.Port == srv.Port && aSrv.Priority == srv.Priority &&
@@ -35,13 +35,13 @@ func (s *SrvManager) Add(srv *net.SRV) error {
 
 // Remove removes the record to the record set if it exists
 func (s *SrvManager) Remove(srv *net.SRV) error {
-	log.Info("remove called")
+	log.Debug("Remove called")
 	newRecordSet := make([]net.SRV, 0)
 	for _, aSrv := range s.SrvRecordSet {
 		// if that record is in the set already, remove it, else copy it over
 		if aSrv.Port == srv.Port && aSrv.Priority == srv.Priority &&
 			aSrv.Target == srv.Target && aSrv.Weight == aSrv.Weight {
-			log.Debugf("Removing record %+v from list", aSrv)
+			log.Infof("Removing record %+v from list", aSrv)
 		} else {
 			newRecordSet = append(newRecordSet, aSrv)
 		}

--- a/dns/route53/dns.go
+++ b/dns/route53/dns.go
@@ -32,7 +32,7 @@ func NewSRVManager(client *Client, hostedZoneID string, recordName string, ttl u
 
 // edit provides both add and removal capabilities
 func (s *SRVManager) edit(add bool, srv *net.SRV) error {
-	log.Infof("Looking up SRV resource record set for %s", s.recordName)
+	log.Debugf("Looking up SRV resource record set for %s", s.recordName)
 	currentResourceRecordSet, err := s.client.GetResourceRecordSetByName(s.hostedZoneID, s.recordName, "SRV")
 	if err != nil {
 		return err
@@ -41,17 +41,17 @@ func (s *SRVManager) edit(add bool, srv *net.SRV) error {
 	var currentResourceRecords []*route53Client.ResourceRecord
 
 	if currentResourceRecordSet == nil {
-		log.Infof("Resource Record set for %s doesn't exist", s.recordName)
+		log.Debugf("Resource Record set for %s doesn't exist", s.recordName)
 		currentResourceRecords = []*route53Client.ResourceRecord{}
 	} else {
-		log.Infof("Resource Record set for %s already exists", s.recordName)
+		log.Debugf("Resource Record set for %s already exists", s.recordName)
 		currentResourceRecords = currentResourceRecordSet.ResourceRecords
 	}
 
 	newResourceRecords := editResourceRecords(add, currentResourceRecords, srv)
 
 	if !resourceRecordsDiffer(currentResourceRecords, newResourceRecords) {
-		log.Infof("Skipped update, no change needed.")
+		log.Debugf("Skipped update, no change needed.")
 	} else {
 		resourceRecordSet := &route53Client.ResourceRecordSet{
 			TTL:  aws.Int64(int64(s.ttl)),
@@ -71,7 +71,8 @@ func (s *SRVManager) edit(add bool, srv *net.SRV) error {
 			resourceRecordSet.ResourceRecords = currentResourceRecords
 		}
 
-		log.Infof("%s record(s): %+v", action, resourceRecordSet.ResourceRecords)
+		log.Infof("%s record %+v", action, srv)
+		log.Tracef("Full record set: %+v", resourceRecordSet.ResourceRecords)
 		_, err := s.client.ChangeRecord(s.hostedZoneID, action, resourceRecordSet)
 		if err != nil {
 			return err


### PR DESCRIPTION
This makes log levels configurable in the CLI, and unifies log levels.

Actual changes are logged with `info` (the default log level), debug logs doing no real changes are logged with `debug`, or in case of auxillary, more verbose data, `trace`.