### PR TITLE
checker/healthchecks/tcp: don't use defer to close connection

### DIFF
--- a/checker/healthchecks/tcp/main.go
+++ b/checker/healthchecks/tcp/main.go
@@ -48,7 +48,8 @@ func (hc *Healthcheck) Run(ctx context.Context, healthyChan chan<- bool) {
 				healthyChan <- false
 				continue
 			}
-			defer conn.Close()
+			// don't defer, close immediately
+			conn.Close()
 			log.Infof("%s is reachable", hc.target)
 			healthyChan <- true
 		}


### PR DESCRIPTION
There's nothing to be done with this connection, so immediately close it
(instead of deferring the cleanup to the end of the function) which
never exits.